### PR TITLE
fix: correct conversation pagination count

### DIFF
--- a/src/agents/AgentChatSystem.js
+++ b/src/agents/AgentChatSystem.js
@@ -464,17 +464,18 @@ class AgentChatSystem extends EventEmitter {
 
   /**
    * Get all conversations for a user
-   */
+  */
   getUserConversations(userId, limit = 50, offset = 0) {
-    const userConversations = Array.from(this.conversations.values())
+    const allUserConversations = Array.from(this.conversations.values())
       .filter(conv => conv.userId === userId)
-      .sort((a, b) => b.lastActivity - a.lastActivity)
-      .slice(offset, offset + limit);
+      .sort((a, b) => b.lastActivity - a.lastActivity);
+
+    const paginatedConversations = allUserConversations.slice(offset, offset + limit);
 
     return {
       success: true,
-      conversations: userConversations.map(conv => this.sanitizeConversation(conv)),
-      total: userConversations.length
+      conversations: paginatedConversations.map(conv => this.sanitizeConversation(conv)),
+      total: allUserConversations.length
     };
   }
 

--- a/tests/AgentChatSystem.test.js
+++ b/tests/AgentChatSystem.test.js
@@ -1,0 +1,23 @@
+const AuthSystem = require('../src/auth/AuthSystem');
+const AgentChatSystem = require('../src/agents/AgentChatSystem');
+
+describe('AgentChatSystem.getUserConversations', () => {
+  test('returns correct total count regardless of pagination', async () => {
+    const authSystem = new AuthSystem();
+    const { user } = await authSystem.register({
+      email: 'test@example.com',
+      password: 'password123',
+      firstName: 'Test',
+      lastName: 'User'
+    });
+    const chatSystem = new AgentChatSystem(authSystem);
+
+    await chatSystem.startConversation(user.id, 'meeting_facilitator');
+    await chatSystem.startConversation(user.id, 'meeting_facilitator');
+    await chatSystem.startConversation(user.id, 'meeting_facilitator');
+
+    const result = chatSystem.getUserConversations(user.id, 2, 0);
+    expect(result.conversations).toHaveLength(2);
+    expect(result.total).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- fix incorrect total conversation count in pagination
- add regression test for conversation pagination

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: No matching version found for helm@>=3.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2afef9d08327bdcb9932a3ea1fe6