### PR TITLE
feat: add dashboard hub and routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Agentic Boardroom
+
+Local development and deployment preparation.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   cd ui && npm install
+   ```
+2. Start the API server:
+   ```bash
+   npm start
+   ```
+3. Start the dashboard development server:
+   ```bash
+   npm run dashboard
+   ```
+   The static dashboards are served on http://localhost:8080 while the API server runs on http://localhost:3000.
+
+## Dashboards
+
+- Overview: http://localhost:3000/
+- Dashboard hub: http://localhost:3000/dashboards
+- Executive: http://localhost:3000/dashboards/executive
+- Operations: http://localhost:3000/dashboards/operations
+- Technical: http://localhost:3000/dashboards/technical
+
+## Building UI Assets
+
+Generate production assets for deployment:
+```bash
+npm run build:ui
+```

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,24 @@ class AgenticBoardroomServer {
       res.sendFile(path.join(__dirname, '../ui/dashboard/index.html'));
     });
 
+    // Dashboard hub
+    this.app.get('/dashboards', (req, res) => {
+      res.sendFile(path.join(__dirname, '../ui/dashboards/index.html'));
+    });
+
+    // Specific dashboards
+    this.app.get('/dashboards/:type', (req, res) => {
+      const file = path.join(
+        __dirname,
+        `../ui/dashboards/${req.params.type}.html`
+      );
+      res.sendFile(file, (err) => {
+        if (err) {
+          res.status(404).send('Dashboard not found');
+        }
+      });
+    });
+
     // Authentication routes
     this.setupAuthRoutes();
     

--- a/ui/dashboards/executive.html
+++ b/ui/dashboards/executive.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Executive Dashboard - Agentic Boardroom</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+  <style>
+    .gradient-bg { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); }
+  </style>
+</head>
+<body class="bg-gray-50 font-sans">
+  <header class="gradient-bg text-white shadow-lg">
+    <div class="container mx-auto px-6 py-4">
+      <h1 class="text-3xl font-bold">Executive Dashboard</h1>
+    </div>
+  </header>
+  <main class="container mx-auto px-6 py-8">
+    <p class="text-gray-600">Detailed executive metrics coming soon.</p>
+  </main>
+</body>
+</html>

--- a/ui/dashboards/index.html
+++ b/ui/dashboards/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboards - Agentic Boardroom</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50 font-sans">
+  <div class="min-h-screen flex flex-col items-center justify-center p-8">
+    <h1 class="text-3xl font-bold mb-8">📊 Dashboard Hub</h1>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-4xl">
+      <a href="/dashboards/executive" class="bg-white card-shadow rounded-lg p-6 text-center hover:bg-blue-50 transition">
+        <i class="fas fa-briefcase text-blue-600 text-3xl mb-2"></i>
+        <p class="font-semibold">Executive</p>
+      </a>
+      <a href="/dashboards/operations" class="bg-white card-shadow rounded-lg p-6 text-center hover:bg-green-50 transition">
+        <i class="fas fa-industry text-green-600 text-3xl mb-2"></i>
+        <p class="font-semibold">Operations</p>
+      </a>
+      <a href="/dashboards/technical" class="bg-white card-shadow rounded-lg p-6 text-center hover:bg-purple-50 transition">
+        <i class="fas fa-microchip text-purple-600 text-3xl mb-2"></i>
+        <p class="font-semibold">Technical</p>
+      </a>
+    </div>
+  </div>
+</body>
+</html>

--- a/ui/dashboards/operations.html
+++ b/ui/dashboards/operations.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Operations Dashboard - Agentic Boardroom</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+  <style>
+    .gradient-bg { background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%); }
+  </style>
+</head>
+<body class="bg-gray-50 font-sans">
+  <header class="gradient-bg text-white shadow-lg">
+    <div class="container mx-auto px-6 py-4">
+      <h1 class="text-3xl font-bold">Operations Dashboard</h1>
+    </div>
+  </header>
+  <main class="container mx-auto px-6 py-8">
+    <p class="text-gray-600">Operational insights coming soon.</p>
+  </main>
+</body>
+</html>

--- a/ui/dashboards/technical.html
+++ b/ui/dashboards/technical.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Technical Dashboard - Agentic Boardroom</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+  <style>
+    .gradient-bg { background: linear-gradient(135deg, #8b5cf6 0%, #6d28d9 100%); }
+  </style>
+</head>
+<body class="bg-gray-50 font-sans">
+  <header class="gradient-bg text-white shadow-lg">
+    <div class="container mx-auto px-6 py-4">
+      <h1 class="text-3xl font-bold">Technical Dashboard</h1>
+    </div>
+  </header>
+  <main class="container mx-auto px-6 py-8">
+    <p class="text-gray-600">Technical system metrics coming soon.</p>
+  </main>
+</body>
+</html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "agentic-boardroom-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "http-server -c-1 -p 8080",
+    "build": "mkdir -p dist && cp -r dashboard dist/ && cp -r dashboards dist/"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add dashboard hub with links to executive, operations, and technical views
- serve new dashboards through express routes
- document local setup and dashboard locations

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden when fetching packages)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `cd ui && npm install --no-audit --no-fund` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2bf15cbc832782169ca76c27471b